### PR TITLE
feat: add RepeatOrdinalWeek to Planning for Nth-weekday monthly recurrence

### DIFF
--- a/Microting.ItemsPlanningBase/Infrastructure/Data/Entities/Planning.cs
+++ b/Microting.ItemsPlanningBase/Infrastructure/Data/Entities/Planning.cs
@@ -48,6 +48,8 @@ public class Planning : PnBase
 
     public int? DayOfMonth { get; set; }
 
+    public int? RepeatOrdinalWeek { get; set; }
+
     public DateTime? LastExecutedTime { get; set; }
 
     public DateTime? NextExecutionTime { get; set; }

--- a/Microting.ItemsPlanningBase/Infrastructure/Data/Entities/PlanningVersion.cs
+++ b/Microting.ItemsPlanningBase/Infrastructure/Data/Entities/PlanningVersion.cs
@@ -47,6 +47,8 @@ public class PlanningVersion : BaseEntity
 
     public int? DayOfMonth { get; set; }
 
+    public int? RepeatOrdinalWeek { get; set; }
+
     public DateTime? LastExecutedTime { get; set; }
 
     public DateTime? NextExecutionTime { get; set; }

--- a/Microting.ItemsPlanningBase/Migrations/20260620135132_AddRepeatOrdinalWeekToPlanning.Designer.cs
+++ b/Microting.ItemsPlanningBase/Migrations/20260620135132_AddRepeatOrdinalWeekToPlanning.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microting.ItemsPlanningBase.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using Microting.ItemsPlanningBase.Infrastructure.Data;
 namespace Microting.ItemsPlanningBase.Migrations
 {
     [DbContext(typeof(ItemsPlanningPnDbContext))]
-    partial class ItemsPlanningPnDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260620135132_AddRepeatOrdinalWeekToPlanning")]
+    partial class AddRepeatOrdinalWeekToPlanning
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Microting.ItemsPlanningBase/Migrations/20260620135132_AddRepeatOrdinalWeekToPlanning.cs
+++ b/Microting.ItemsPlanningBase/Migrations/20260620135132_AddRepeatOrdinalWeekToPlanning.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Microting.ItemsPlanningBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRepeatOrdinalWeekToPlanning : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "RepeatOrdinalWeek",
+                table: "PlanningVersions",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "RepeatOrdinalWeek",
+                table: "Plannings",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RepeatOrdinalWeek",
+                table: "PlanningVersions");
+
+            migrationBuilder.DropColumn(
+                name: "RepeatOrdinalWeek",
+                table: "Plannings");
+        }
+    }
+}


### PR DESCRIPTION
Adds nullable `int RepeatOrdinalWeek` to `Planning` + `PlanningVersion` (+ EF migration adding the column to both `Plannings` and `PlanningVersions`) so the items-planning scheduler can compute Nth-weekday-of-month deadlines (e.g. "3rd Thursday") instead of day-of-month.

Required by the backend-config fix for duplicate ordinal-week calendar occurrences (a "3rd Thursday" rule currently also renders on the day-of-month date). Mirrors the `AddRepeatEndModeAndOccurrences` precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)